### PR TITLE
changing closing h4 tag to opening

### DIFF
--- a/1-1-elements.html
+++ b/1-1-elements.html
@@ -1484,7 +1484,7 @@ C.make_static("scheme-define-good-enough-2");
 
 <p> In the definition of good-enough? above, guess and x are bound variables but &lt;, -, abs, and square are free. The meaning of good-enough? should be independent of the names we choose for guess and x so long as they are distinct and different from <, -, abs, and square. (If we renamed guess to abs we would have introduced a bug by capturing the variable abs. It would have changed from free to bound.) The meaning of good-enough? is not independent of the names of its free variables, however. It surely depends upon the fact (external to this definition) that the symbol abs names a procedure for computing the absolute value of a number. Good-enough? will compute a different function if we substitute cos for abs in its definition.
 
-</h4>Internal definitions and block structure</h4>
+<h4>Internal definitions and block structure</h4>
 
 <p> We have one kind of name isolation available to us so far: The formal parameters of a procedure are local to the body of the procedure. The square-root program illustrates another way in which we would like to control the use of names. The existing program consists of separate procedures:
 


### PR DESCRIPTION
Fixing what looks like a closing h4 tag where it should be an opening tag.  With that being inside two closing tags, "Internal definitions and block structure" looked like part of the normal paragraph text before it and read as an incomplete sentence.

Verified with another SICP text that it is in fact a subheading that is supposed to be there, tested this in a browser and looks good and "Internal definitions and block structure" shows up in the side bar table of contents.
