### PR TITLE
Update 1.9 exercise to use 'process' instead of 'procedure'

### DIFF
--- a/1-2-procedures.html
+++ b/1-2-procedures.html
@@ -277,10 +277,10 @@ C.add_dep("scheme-define-plus-dec-inc", ["scheme-define-inc-dec"]);
 <div id="scheme-ex-dec-inc-mcq"></div>
 <script>
 C.make_MCQ("scheme-ex-dec-inc-mcq",
-        ["The first procedure is recursive",
-         "The second procedure is iterative"],
-        ["The first procedure is iterative",
-         "The second procedure is recursive"
+        ["The first process is recursive",
+         "The second process is iterative"],
+        ["The first process is iterative",
+         "The second process is recursive"
         ]);
 </script>
 


### PR DESCRIPTION
I noticed when going through exercise 1.9 that the question asks the reader "Are these processes iterative or recursive?", yet all the multiple choice options use the word "procedure" (should be "process").