### PR TITLE
Reapplying lost edits.

### DIFF
--- a/1-1-elements.html
+++ b/1-1-elements.html
@@ -643,13 +643,13 @@ C.prompt("scheme-define-square");
 <p> The general form of a procedure definition is
 
 <div id="scheme-define-syntax" class='static'>
-(define (&lt;name&gt; &lt;formal parameters&gt;) &lt;body&gt;)
+(define (&lt;<em>name</em>&gt; &lt;<em>formal parameters</em>&gt;) &lt;<em>body</em>&gt;)
 </div>
 <script>
 C.make_static("scheme-define-syntax");
 </script>
 
-<p> The name is a symbol to be associated with the procedure definition in the environment.<a name="footnote_link_1-13" class="footnote_link" href="#footnote_1-13">13</a> The formal parameters are the names used within the body of the procedure to refer to the corresponding arguments of the procedure. The body is an expression that will yield the value of the procedure application when the formal parameters are replaced by the actual arguments to which the procedure is applied.<a name="footnote_link_1-14" class="footnote_link" href="#footnote_1-14">14</a> The name and the formal parameters are grouped within parentheses, just as they would be in an actual call to the procedure being defined.
+<p> The &lt;<em>name</em>&gt; is a symbol to be associated with the procedure definition in the environment.<a name="footnote_link_1-13" class="footnote_link" href="#footnote_1-13">13</a> The &lt;<em>formal parameters</em>&gt; are the names used within the body of the procedure to refer to the corresponding arguments of the procedure. The &lt;<em>body</em>&gt; is an expression that will yield the value of the procedure application when the formal parameters are replaced by the actual arguments to which the procedure is applied.<a name="footnote_link_1-14" class="footnote_link" href="#footnote_1-14">14</a> The &lt;<em>name</em>&gt; and the &lt;<em>formal parameters</em>&gt; are grouped within parentheses, just as they would be in an actual call to the procedure being defined.
 
 <p> Having defined square, we can now use it:
 
@@ -920,7 +920,7 @@ C.no_output_frozen_prompt("scheme-cond-syntax");
 
 <p> Conditional expressions are evaluated as follows. The predicate <tt>&lt;p1&gt;</tt>; is evaluated first. If its value is false, then <tt>&lt;p2&gt;</tt> is evaluated. If <tt>&lt;p2&gt;</tt>'s value is also false, then <tt>&lt;p3&gt;</tt> is evaluated. This process continues until a predicate is found whose value is true, in which case the interpreter returns the value of the corresponding consequent expression <tt>&lt;e&gt;</tt> of the clause as the value of the conditional expression. If none of the <tt>&lt;p&gt;</tt>'s is found to be true, the value of the cond is undefined.
 
-<p> The word predicate is used for procedures that return true or false, as well as for expressions that evaluate to true or false. The absolute-value procedure abs makes use of the primitive predicates <tt>&lt;</tt>, <tt>&gt;</tt>, and <tt>=</tt>.<a name="footnote_link_1-18" class="footnote_link" href="#footnote_1-18">18</a> These take two numbers as arguments and test whether the first number is, respectively, greater than, less than, or equal to the second number, returning true or false accordingly.
+<p> The word predicate is used for procedures that return true or false, as well as for expressions that evaluate to true or false. The absolute-value procedure abs makes use of the primitive predicates <tt>&gt;</tt>, <tt>&lt;</tt>, and <tt>=</tt>.<a name="footnote_link_1-18" class="footnote_link" href="#footnote_1-18">18</a> These take two numbers as arguments and test whether the first number is, respectively, greater than, less than, or equal to the second number, returning true or false accordingly.
 
 <p> Another way to write the absolute-value procedure is
 
@@ -978,7 +978,7 @@ C.no_output_frozen_prompt("scheme-cond-syntax");
 
 <p> Notice that and and or are special forms, not procedures, because the subexpressions are not necessarily all evaluated. Not is an ordinary procedure.
 
-As an example of how these are used, the condition that a number $x$ be in the range $5 &lt; x &lt; 10$ may be expressed as
+<p> As an example of how these are used, the condition that a number $x$ be in the range $5 &lt; x &lt; 10$ may be expressed as
 
 <div id="scheme-between">
 (and (> x 5) (&lt; x 10))

--- a/content/1-1-elements.content.html
+++ b/content/1-1-elements.content.html
@@ -514,13 +514,13 @@ C.prompt("scheme-define-square");
 <p> The general form of a procedure definition is
 
 <div id="scheme-define-syntax" class='static'>
-(define (&lt;name&gt; &lt;formal parameters&gt;) &lt;body&gt;)
+(define (&lt;<em>name</em>&gt; &lt;<em>formal parameters</em>&gt;) &lt;<em>body</em>&gt;)
 </div>
 <script>
 C.make_static("scheme-define-syntax");
 </script>
 
-<p> The name is a symbol to be associated with the procedure definition in the environment.<a name="footnote_link_1-13" class="footnote_link" href="#footnote_1-13">13</a> The formal parameters are the names used within the body of the procedure to refer to the corresponding arguments of the procedure. The body is an expression that will yield the value of the procedure application when the formal parameters are replaced by the actual arguments to which the procedure is applied.<a name="footnote_link_1-14" class="footnote_link" href="#footnote_1-14">14</a> The name and the formal parameters are grouped within parentheses, just as they would be in an actual call to the procedure being defined.
+<p> The &lt;<em>name</em>&gt; is a symbol to be associated with the procedure definition in the environment.<a name="footnote_link_1-13" class="footnote_link" href="#footnote_1-13">13</a> The &lt;<em>formal parameters</em>&gt; are the names used within the body of the procedure to refer to the corresponding arguments of the procedure. The &lt;<em>body</em>&gt; is an expression that will yield the value of the procedure application when the formal parameters are replaced by the actual arguments to which the procedure is applied.<a name="footnote_link_1-14" class="footnote_link" href="#footnote_1-14">14</a> The &lt;<em>name</em>&gt; and the &lt;<em>formal parameters</em>&gt; are grouped within parentheses, just as they would be in an actual call to the procedure being defined.
 
 <p> Having defined square, we can now use it:
 
@@ -791,7 +791,7 @@ C.no_output_frozen_prompt("scheme-cond-syntax");
 
 <p> Conditional expressions are evaluated as follows. The predicate <tt>&lt;p1&gt;</tt>; is evaluated first. If its value is false, then <tt>&lt;p2&gt;</tt> is evaluated. If <tt>&lt;p2&gt;</tt>'s value is also false, then <tt>&lt;p3&gt;</tt> is evaluated. This process continues until a predicate is found whose value is true, in which case the interpreter returns the value of the corresponding consequent expression <tt>&lt;e&gt;</tt> of the clause as the value of the conditional expression. If none of the <tt>&lt;p&gt;</tt>'s is found to be true, the value of the cond is undefined.
 
-<p> The word predicate is used for procedures that return true or false, as well as for expressions that evaluate to true or false. The absolute-value procedure abs makes use of the primitive predicates <tt>&lt;</tt>, <tt>&gt;</tt>, and <tt>=</tt>.<a name="footnote_link_1-18" class="footnote_link" href="#footnote_1-18">18</a> These take two numbers as arguments and test whether the first number is, respectively, greater than, less than, or equal to the second number, returning true or false accordingly.
+<p> The word predicate is used for procedures that return true or false, as well as for expressions that evaluate to true or false. The absolute-value procedure abs makes use of the primitive predicates <tt>&gt;</tt>, <tt>&lt;</tt>, and <tt>=</tt>.<a name="footnote_link_1-18" class="footnote_link" href="#footnote_1-18">18</a> These take two numbers as arguments and test whether the first number is, respectively, greater than, less than, or equal to the second number, returning true or false accordingly.
 
 <p> Another way to write the absolute-value procedure is
 
@@ -849,7 +849,7 @@ C.no_output_frozen_prompt("scheme-cond-syntax");
 
 <p> Notice that and and or are special forms, not procedures, because the subexpressions are not necessarily all evaluated. Not is an ordinary procedure.
 
-As an example of how these are used, the condition that a number $x$ be in the range $5 &lt; x &lt; 10$ may be expressed as
+<p> As an example of how these are used, the condition that a number $x$ be in the range $5 &lt; x &lt; 10$ may be expressed as
 
 <div id="scheme-between">
 (and (> x 5) (&lt; x 10))


### PR DESCRIPTION
These corrections were accepted previously but appear to have been lost due to careless merging.
Specifically:
* The style of the text must be consistent with footnote 13, or that footnote makes no sense. (This point may also need correction later on, I haven't read that far.)
* "respectively" means the lists must be in the same order. Changed "<, >, and =" to ">, <, and =" to match "respectively, greater than, less than, or equal to" as in the original text.
* Inserted missing paragraph break that was in the original text.