### PR TITLE
Correct function definition in exercise 1.11

### DIFF
--- a/content/1-2-procedures.content.html
+++ b/content/1-2-procedures.content.html
@@ -374,7 +374,7 @@ C.add_dep("scheme-count-change-100", ["scheme-define-count-change"]);
 
 
 <div class="exercise">
-<p> <b> Exercise 1.11. </b> A function $f$ is defined by the rule that $f(n) = n$ if $n&lt;3$ and $f(n) = f(n - 1) + 2f(n - 2) + 3f(n - 3)$ if $n &gt; 3$. Write a procedure that computes $f$ by means of a recursive process.
+<p> <b> Exercise 1.11. </b> A function $f$ is defined by the rule that $f(n) = n$ if $n&lt;3$ and $f(n) = f(n - 1) + 2f(n - 2) + 3f(n - 3)$ if $n &gt;= 3$. Write a procedure that computes $f$ by means of a recursive process.
 
 <p> Write a procedure that computes f by means of an iterative process.
 


### PR DESCRIPTION
Missing equals in else branch of function definition. "greater than" should be "greater than or equal to" according to the book (2nd ed., MIT Press, c1996)